### PR TITLE
Mb/early traversal termination

### DIFF
--- a/src/EarlyTraversalTerminationException.php
+++ b/src/EarlyTraversalTerminationException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace TreeNodes;
+
+use Exception;
+
+class EarlyTraversalTerminationException extends Exception {}

--- a/src/GenericTreeNodeVisitor.php
+++ b/src/GenericTreeNodeVisitor.php
@@ -36,17 +36,12 @@ class GenericTreeNodeVisitor implements TreeNodeVisitor
                 $leftmostChild = $leftmostChild->getLeftSibling();
             }
         }
-        try {
-            ($this->visitorCallable)($node);
-            $this->visitPreOrder($leftmostChild, false);
-            
-            if (!$atRoot) {
-                $this->visitPreOrder($node->getRightSibling(), false);
-            }
-        } catch (EarlyTraversalTerminationException $e) {
-            return;
+        ($this->visitorCallable)($node);
+        $this->visitPreOrder($leftmostChild, false);
+        
+        if (!$atRoot) {
+            $this->visitPreOrder($node->getRightSibling(), false);
         }
-
     }
 
     /**
@@ -68,15 +63,12 @@ class GenericTreeNodeVisitor implements TreeNodeVisitor
             }
         }
 
-        try {
-            $this->visitPostOrder($leftmostChild, false);
-            ($this->visitorCallable)($node);
-            if (!$atRoot) {
-                $this->visitPostOrder($node->getRightSibling(), false);
-            }
-        } catch (EarlyTraversalTerminationException $e) {
-            return;
+        $this->visitPostOrder($leftmostChild, false);
+        ($this->visitorCallable)($node);
+        if (!$atRoot) {
+            $this->visitPostOrder($node->getRightSibling(), false);
         }
+
     }
 
             /**
@@ -98,18 +90,15 @@ class GenericTreeNodeVisitor implements TreeNodeVisitor
         $collectNextLevelNodes = static function(SortableTreeNode $treeNode) use (&$nextLevelNodes) { 
              $nextLevelNodes = [...$nextLevelNodes, ...$treeNode->getChildren()];
         };
-        try {
-            do {
-                while (!empty($currlevelNodes)) {
-                    $currNode = \array_shift($currlevelNodes);
-                    $collectNextLevelNodes($currNode);
-                    ($this->visitorCallable)($currNode);
-                }
-                $currlevelNodes = $nextLevelNodes;
-                $nextLevelNodes = [];
-            } while (!empty($currlevelNodes));
-        } catch (EarlyTraversalTerminationException $e) {
-            return;
-        }
+        do {
+            while (!empty($currlevelNodes)) {
+                $currNode = \array_shift($currlevelNodes);
+                $collectNextLevelNodes($currNode);
+                ($this->visitorCallable)($currNode);
+            }
+            $currlevelNodes = $nextLevelNodes;
+            $nextLevelNodes = [];
+        } while (!empty($currlevelNodes));
+        
     }
 }

--- a/tests/Unit/GenericTreeNodeVisitorTest.php
+++ b/tests/Unit/GenericTreeNodeVisitorTest.php
@@ -11,6 +11,7 @@ use TreeNodes\GenericSortableTreeNode;
 use TreeNodes\TreeNodeVisitor;
 use TreeNodes\GenericTreeNodeVisitor;
 use TreeNodes\SortableTreeNode;
+use TreeNodes\EarlyTraversalTerminationException;
 
 final class GenericTreeNodeVisitorTest extends TestCase
 {
@@ -102,6 +103,71 @@ final class GenericTreeNodeVisitorTest extends TestCase
         $this->orderString = "";
         $expectedOrder = "root, 1, 2, 3, 4, 5, 2.1, 2.2, 3.1, 2.1.1, 2.1.2";
         $this->orderWritingVisitor->visitLevelOrder($sortableTreeNode);
+        $errMsg = 'Expected order: [' . $expectedOrder . '] - actual order [' . $this->orderString . '].';
+        $this->assertEquals($expectedOrder, $this->orderString, $errMsg);
+    }
+
+    
+    public function testEarlyPreOrderTraversalTermination(): void
+    {
+        $sortableTreeNode = $this->demoTree;
+        $this->orderString = "";
+        $expectedOrder = "root, 1, 2, 2.1";
+        $visitFn = function(SortableTreeNode $treeNode) {
+            $separator = '' === $this->orderString ? '' : ', ';
+            $id = $treeNode->getId();
+            $this->orderString .= $separator . $id;
+            if ('2.1' === $id) {
+                throw new EarlyTraversalTerminationException();
+            }
+        };
+        $visitor = new GenericTreeNodeVisitor($visitFn);
+        try {
+            $visitor->visitPreOrder($sortableTreeNode);
+        } catch (EarlyTraversalTerminationException) {}
+        $errMsg = 'Expected order: [' . $expectedOrder . '] - actual order [' . $this->orderString . '].';
+        $this->assertEquals($expectedOrder, $this->orderString, $errMsg);
+    }
+
+    public function testEarlyPostOrderTraversalTermination(): void
+    {
+        $sortableTreeNode = $this->demoTree;
+        $this->orderString = "";
+        $expectedOrder = "1, 2.1.1, 2.1.2, 2.1";
+        $visitFn = function(SortableTreeNode $treeNode) {
+            $separator = '' === $this->orderString ? '' : ', ';
+            $id = $treeNode->getId();
+            $this->orderString .= $separator . $id;
+            if ('2.1' === $id) {
+                throw new EarlyTraversalTerminationException();
+            }
+        };
+        $visitor = new GenericTreeNodeVisitor($visitFn);
+        try {
+            $visitor->visitPostOrder($sortableTreeNode);
+        } catch (EarlyTraversalTerminationException) {}
+
+        $errMsg = 'Expected order: [' . $expectedOrder . '] - actual order [' . $this->orderString . '].';
+        $this->assertEquals($expectedOrder, $this->orderString, $errMsg);
+    }
+
+    public function testEarlyLevelOrderTraversalTermination(): void
+    {
+        $sortableTreeNode = $this->demoTree;
+        $this->orderString = "";
+        $expectedOrder = "root, 1, 2, 3, 4, 5, 2.1";
+        $visitFn = function(SortableTreeNode $treeNode) {
+            $separator = '' === $this->orderString ? '' : ', ';
+            $id = $treeNode->getId();
+            $this->orderString .= $separator . $id;
+            if ('2.1' === $id) {
+                throw new EarlyTraversalTerminationException();
+            }
+        };
+        $visitor = new GenericTreeNodeVisitor($visitFn);
+        try {
+            $visitor->visitLevelOrder($sortableTreeNode);
+        } catch (EarlyTraversalTerminationException) {}
         $errMsg = 'Expected order: [' . $expectedOrder . '] - actual order [' . $this->orderString . '].';
         $this->assertEquals($expectedOrder, $this->orderString, $errMsg);
     }


### PR DESCRIPTION
Allow early termination of tree-traversals in visitors via throwing EarlyTraversalTerminationException in visitor-function and catching it in the caller to TreeNodeVisitor->visit[Order]Order.

Can be used like:
    
    $someIdToTerminateOn = 'foo';
    $exists = false;
    $earlyTerminatingFunc = static function(TreeNode $n) use ($someIdToTerminateOn, $exists) {
        if ($someIdToTerminateOn === $n->getId()) {
            $exists = true;
            throw new EarlyTraversalTerminationException();
        }
    } 
    $visitor = new GenericTreeNodeVisitor($earlyTerminatingFunc);
    try {
        $visitor->visitPreOrder($tree);
    } catch (EarlyTraversalTerminationException) {}

For large trees and/or visitor-functions which take a lot of time per visited node, this will  *significantly* increase performance.

NOTE: Long term, a better solution is to refactor the methods to return null|EarlyTraversalTermination (refactor exception to empty response class) - but that requires chaning the signature, which should be for another task.